### PR TITLE
enhancements: use Content-Location, optionally use just the leaf of a filename

### DIFF
--- a/smhtml/cli.py
+++ b/smhtml/cli.py
@@ -34,6 +34,8 @@ def option_parser():
                      help="Verbose mode")
     psr.add_argument("-q", "--quiet", action="store_const", const=2,
                      dest="verbose", help="Quiet mode")
+    psr.add_argument("--path_names_only", action='store_true',
+                     help="Use the leaf, not full path, of attached files")
     return psr
 
 
@@ -69,7 +71,7 @@ def main(argv=None):
         try:  # Try to extract given MHTML data
             LOGGER.info("'%s' looks a MHTML data and try to extract files "
                         "from it", args.input)
-            smhtml.extract(args.input, args.output)
+            smhtml.extract(args.input, args.output, args.path_names_only)
         except (ValueError, OSError) as exc:
             print(str(exc), file=sys.stderr)
     else:

--- a/smhtml/loader.py
+++ b/smhtml/loader.py
@@ -49,6 +49,13 @@ def get_or_gen_filename(part, idx=0):
     :return: A filename as a string
     """
     filename = part.get_filename()
+
+    # if filename is not set in Content-Disposition, look in location
+    if not filename:
+        location = part.get_params(header='Content-Location')
+        if location and location[0]:
+            filename = location[0][0]
+
     if not filename:
         fileext = mimetypes.guess_extension(part.get_content_type())
         if not fileext:

--- a/smhtml/loader.py
+++ b/smhtml/loader.py
@@ -142,13 +142,14 @@ def load(filepath):
     return list(load_itr(filepath))
 
 
-def extract(filepath, output):
+def extract(filepath, output, path_names_only=False):
     """
     Load and extract each part of MIME multi-part data as files from given data
     as a file.
 
     :param filepath: :class:`pathlib.Path` object represents input
     :param output: :class:`pathlib.Path` object represents output dir
+    :param path_names_only: Use the leaf, not full path, of attached files
     :raises: ValueError
     """
     if output == "-":
@@ -159,10 +160,14 @@ def extract(filepath, output):
 
     os.makedirs(output)
     for inf in load_itr(filepath):
-        outpath = os.path.join(output, inf["filename"])
+        filename = inf["filename"]
+        if path_names_only:
+            filename = os.path.split(filename)[-1]
+
+        outpath = os.path.join(output, filename)
         outdir = os.path.dirname(outpath)
 
-        LOGGER.debug("Extract %s from %s", inf["filename"], filepath)
+        LOGGER.debug("Extract %s from %s", filename, filepath)
 
         if not os.path.exists(outdir):
             os.makedirs(outdir)


### PR DESCRIPTION
Hi,
I thought I'd add these contributions to the project.
Many mht files (including the example `python-smhtml.mhtml`) use `Content-Location`, so it makes sense to check it for a filename.
Also, sometimes the "filename" is an absolute path, and so I added a flag that will only use the last part (leaf) of the name.
-Ben
