### PR TITLE
enhancement: optionally use content-location

### DIFF
--- a/smhtml/cli.py
+++ b/smhtml/cli.py
@@ -34,6 +34,8 @@ def option_parser():
                      help="Verbose mode")
     psr.add_argument("-q", "--quiet", action="store_const", const=2,
                      dest="verbose", help="Quiet mode")
+    psr.add_argument("--uselocation", action='store_true',
+                     help="Use content-location header for output path")
     psr.add_argument("--usebasename", action='store_true',
                      help="Use basename, not full path, when writing files")
     return psr
@@ -71,7 +73,8 @@ def main(argv=None):
         try:  # Try to extract given MHTML data
             LOGGER.info("'%s' looks a MHTML data and try to extract files "
                         "from it", args.input)
-            smhtml.extract(args.input, args.output, args.usebasename)
+            smhtml.extract(args.input, args.output, args.uselocation,
+                           args.usebasename)
         except (ValueError, OSError) as exc:
             print(str(exc), file=sys.stderr)
     else:

--- a/smhtml/cli.py
+++ b/smhtml/cli.py
@@ -34,8 +34,6 @@ def option_parser():
                      help="Verbose mode")
     psr.add_argument("-q", "--quiet", action="store_const", const=2,
                      dest="verbose", help="Quiet mode")
-    psr.add_argument("--uselocation", action='store_true',
-                     help="Use content-location header for output path")
     psr.add_argument("--usebasename", action='store_true',
                      help="Use basename, not full path, when writing files")
     return psr
@@ -73,8 +71,7 @@ def main(argv=None):
         try:  # Try to extract given MHTML data
             LOGGER.info("'%s' looks a MHTML data and try to extract files "
                         "from it", args.input)
-            smhtml.extract(args.input, args.output, args.uselocation,
-                           args.usebasename)
+            smhtml.extract(args.input, args.output, args.usebasename)
         except (ValueError, OSError) as exc:
             print(str(exc), file=sys.stderr)
     else:


### PR DESCRIPTION
When writing output files, currently Content-Disposition is used to create the output filname. With this change you can specify --uselocation so that the content-location header is also checked. Chrome and others save their mht files with this header set.